### PR TITLE
Avoid semicolons after functions

### DIFF
--- a/nul1fs.c
+++ b/nul1fs.c
@@ -23,14 +23,14 @@ static int strendswith(const char *str, const char *sfx) {
     size_t str_len = strlen(str);
     if (str_len < sfx_len) return 0;
     return (strncmp(str + (str_len - sfx_len), sfx, sfx_len) == 0);
-};
+}
 
 static int nullfs_isdir(const char *path) {
     if (! path) return 0;
     return (strendswith(path, "/") || strendswith(path, "/..")
         || strendswith(path, "/.") || (strcmp(path, "..") == 0)
         || (strcmp(path, ".") == 0));
-};
+}
 
 static int nullfs_getattr(const char *path, struct stat *stbuf) {
     int res = 0;
@@ -53,7 +53,7 @@ static int nullfs_getattr(const char *path, struct stat *stbuf) {
     };
 
     return res;
-};
+}
 
 static int nullfs_readdir(const char *path, void *buf, fuse_fill_dir_t
 filler, off_t offset, struct fuse_file_info *fi) {
@@ -66,7 +66,7 @@ filler, off_t offset, struct fuse_file_info *fi) {
     filler(buf, "..", NULL, 0);
 
     return 0;
-};
+}
 
 static int nullfs_open(const char *path, struct fuse_file_info *fi) {
     (void) fi;
@@ -74,7 +74,7 @@ static int nullfs_open(const char *path, struct fuse_file_info *fi) {
     if (nullfs_isdir(path)) return -ENOENT;
 
     return 0;
-};
+}
 
 static int nullfs_read(const char *path, char *buf, size_t size,
 off_t offset, struct fuse_file_info *fi) {
@@ -86,7 +86,7 @@ off_t offset, struct fuse_file_info *fi) {
     if (nullfs_isdir(path)) return -ENOENT;
 
     return 0;
-};
+}
 
 static int nullfs_write(const char *path, const char *buf, size_t size,
 off_t offset, struct fuse_file_info *fi) {
@@ -97,7 +97,7 @@ off_t offset, struct fuse_file_info *fi) {
     if (nullfs_isdir(path)) return -ENOENT;
 
     return (int) size;
-};
+}
 
 static int nullfs_create(const char *path, mode_t m,
 struct fuse_file_info *fi) {
@@ -106,34 +106,34 @@ struct fuse_file_info *fi) {
     (void) fi;
 
     return 0;
-};
+}
 
 static int nullfs_unlink(const char *path) {
     (void) path;
 
     return 0;
-};
+}
 
 static int nullfs_rename(const char *src, const char *dst) {
     (void) src;
     (void) dst;
 
     return 0;
-};
+}
 
 static int nullfs_truncate(const char *path, off_t o) {
     (void) path;
     (void) o;
 
     return 0;
-};
+}
 
 static int nullfs_chmod(const char *path, mode_t m) {
     (void) path;
     (void) m;
 
     return 0;
-};
+}
 
 static int nullfs_chown(const char *path, uid_t u, gid_t g) {
     (void) path;
@@ -141,14 +141,14 @@ static int nullfs_chown(const char *path, uid_t u, gid_t g) {
     (void) g;
 
     return 0;
-};
+}
 
 static int nullfs_utimens(const char *path, const struct timespec ts[2]) {
     (void) path;
     (void) ts;
 
     return 0;
-};
+}
 
 static struct fuse_operations nullfs_oper = {
     .getattr    = nullfs_getattr,
@@ -169,6 +169,6 @@ static struct fuse_operations nullfs_oper = {
 int main(int argc, char *argv[]) {
     start_t = time(NULL);
     return fuse_main(argc, argv, &nullfs_oper, NULL);
-};
+}
 
 /* vi:set sw=4 et tw=72: */


### PR DESCRIPTION
(this is not permitted by ISO C)

This is a pedantic cleanup, avoiding this error message:

```
nul1fs.c:26:2: error: ISO C does not allow extra ‘;’ outside of a function [-Werror=pedantic]
````